### PR TITLE
Feature: (index,query) Fallback to search INDEX to find ITEM

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ binq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 \
   -d path/to/bin -f jq
 
 # With index server
-binq -s https://progrhy.me/binq-index github.com/peco/peco -d path/to/bin
+binq -s https://progrhy.me/binq-index peco -d path/to/bin
 export BINQ_SERVER=https://progrhy.me/binq-index
 binq jq -d path/to/bin -f jq
 ```

--- a/client/cli.go
+++ b/client/cli.go
@@ -75,14 +75,14 @@ func (c *CLI) Run(args []string) (exit int) {
 	} else if *verbose {
 		logLevel = logs.Info
 	}
-	opts := runOpts{
-		mode:     mode,
-		source:   source,
-		destDir:  *directory,
-		destFile: *file,
-		outs:     c.ErrStream,
-		level:    logLevel,
-		server:   *server,
+	opts := RunOption{
+		Mode:      mode,
+		Source:    source,
+		DestDir:   *directory,
+		DestFile:  *file,
+		Output:    c.ErrStream,
+		LogLevel:  logLevel,
+		ServerURL: *server,
 	}
 	if err := Run(opts); err != nil {
 		fmt.Fprintf(c.ErrStream, "Error! %v\n", err)

--- a/client/cli.go
+++ b/client/cli.go
@@ -63,6 +63,9 @@ func (c *CLI) Run(args []string) (exit int) {
 	if *noExec {
 		mode = mode ^ ModeExecutable
 	}
+	if mode == 0 {
+		mode = ModeDLOnly
+	}
 
 	source := flags.Arg(0)
 

--- a/client/client.go
+++ b/client/client.go
@@ -9,14 +9,12 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/mholt/archiver/v3"
 	"github.com/progrhyme/binq"
 	"github.com/progrhyme/binq/internal/erron"
 	"github.com/progrhyme/binq/internal/logs"
-	"github.com/progrhyme/binq/schema"
 )
 
 type Mode int
@@ -105,67 +103,6 @@ func (r *Runner) Run() (err error) {
 	return nil
 }
 
-// prefetch query metadata for item info to fetch
-func (r *Runner) prefetch() (err error) {
-	if strings.HasPrefix(r.Source, "http") {
-		r.sourceURL = r.Source
-		return nil
-	}
-	if r.ServerURL == nil {
-		return fmt.Errorf("No server is configured. Can't deal with source: %s", r.Source)
-	}
-	// Copy r.ServerURL
-	urlItem, _err := url.Parse(r.ServerURL.String())
-	if _err != nil {
-		// Unexpected case
-		return erron.Errorwf(_err, "Failed to parse server URL: %v", r.ServerURL)
-	}
-	urlItem.Path = path.Join(urlItem.Path, r.Source)
-
-	headers := make(map[string]string)
-	headers["Accept"] = "application/json"
-	req, err := newHttpGetRequest(urlItem.String(), headers)
-	if err != nil {
-		return err
-	}
-	r.Logger.Infof("GET %s", urlItem.String())
-
-	// Use different timeout for index server
-	hc := newHttpClient(httpTimeoutToQueryIndex)
-	res, _err := hc.Do(req)
-	if _err != nil {
-		return erron.Errorwf(_err, "Failed to execute HTTP request")
-	}
-	defer res.Body.Close()
-	if res.StatusCode != 200 {
-		return fmt.Errorf("HTTP response is not OK. Code: %d, URL: %s", res.StatusCode, urlItem.String())
-	}
-
-	var b strings.Builder
-	_, _err = io.Copy(&b, res.Body)
-	if _err != nil {
-		return erron.Errorwf(_err, "Failed to read HTTP response")
-	}
-
-	item, err := schema.DecodeItemJSON([]byte(b.String()))
-	if err != nil {
-		return err
-	}
-	r.Logger.Debugf("Decoded JSON: %+v", item)
-
-	srcURL, err := item.GetLatestURL(schema.ItemURLParam{OS: runtime.GOOS, Arch: runtime.GOARCH})
-	if err != nil {
-		return err
-	}
-	if srcURL == "" {
-		return fmt.Errorf("Can't get source URL from JSON")
-	}
-
-	r.sourceURL = srcURL
-
-	return err
-}
-
 func (r *Runner) fetch() (err error) {
 	if r.sourceURL == "" {
 		return fmt.Errorf("Can't fetch because sourceURL is not set. Source: %s", r.Source)
@@ -218,7 +155,8 @@ func (r *Runner) extract() (err error) {
 	r.extracted = false
 	uai, _err := archiver.ByExtension(r.download)
 	if _err != nil {
-		r.Logger.Noticef("Unarchiver can't be determined. %s", _err)
+		r.Logger.Debugf("Unarchiver can't be determined. %s", _err)
+		r.Logger.Noticef("Skip extraction")
 		return nil
 	}
 

--- a/client/client.go
+++ b/client/client.go
@@ -43,33 +43,35 @@ type Runner struct {
 	extracted  bool
 }
 
-type runOpts struct {
-	mode     Mode
-	source   string
-	destDir  string
-	destFile string
-	outs     io.Writer
-	level    logs.Level
-	server   string
+type RunOption struct {
+	Mode      Mode
+	Source    string
+	DestDir   string
+	DestFile  string
+	Output    io.Writer
+	LogLevel  logs.Level
+	ServerURL string
 }
 
 var defaultRunner Runner
 
-func Run(opt runOpts) (err error) {
-	defaultRunner.Source = opt.source
-	defaultRunner.DestDir = opt.destDir
-	defaultRunner.DestFile = opt.destFile
-	defaultRunner.Logger = logs.New(opt.outs, opt.level, 0)
-	defaultRunner.httpClient = newHttpClient(DefaultHTTPTimeout)
-	if opt.mode == 0 {
+func Run(opt RunOption) (err error) {
+	defaultRunner = Runner{
+		Source:     opt.Source,
+		DestDir:    opt.DestDir,
+		DestFile:   opt.DestFile,
+		Logger:     logs.New(opt.Output, opt.LogLevel, 0),
+		httpClient: newHttpClient(DefaultHTTPTimeout),
+	}
+	if opt.Mode == 0 {
 		defaultRunner.Mode = ModeDefault
 	} else {
-		defaultRunner.Mode = opt.mode
+		defaultRunner.Mode = opt.Mode
 	}
 
 	var urlStr string
-	if opt.server != "" {
-		urlStr = opt.server
+	if opt.ServerURL != "" {
+		urlStr = opt.ServerURL
 	} else if server := os.Getenv(binq.EnvKeyServer); server != "" {
 		urlStr = server
 	}

--- a/client/prefetch.go
+++ b/client/prefetch.go
@@ -1,0 +1,187 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"runtime"
+	"strings"
+
+	"github.com/progrhyme/binq/internal/erron"
+	"github.com/progrhyme/binq/schema"
+)
+
+var errIndexDataNotFound = errors.New("Index Data is Not Found on given URL")
+
+// prefetch query metadata for item info to fetch
+func (r *Runner) prefetch() (err error) {
+	if strings.HasPrefix(r.Source, "http") {
+		r.sourceURL = r.Source
+		return nil
+	}
+	if r.ServerURL == nil {
+		return fmt.Errorf("No server is configured. Can't deal with source: %s", r.Source)
+	}
+
+	// Use different timeout for index server
+	hc := newHttpClient(httpTimeoutToQueryIndex)
+
+	item, _err := r.prefetchItemByURL(hc, r.Source)
+	switch _err {
+	case nil:
+		// OK
+	case errIndexDataNotFound:
+		// Retry
+		if item, err = r.prefetchItemByIndex(hc); err != nil {
+			return err
+		}
+	default:
+		return _err
+	}
+
+	srcURL, err := item.GetLatestURL(schema.ItemURLParam{OS: runtime.GOOS, Arch: runtime.GOARCH})
+	if err != nil {
+		return err
+	}
+	if srcURL == "" {
+		return fmt.Errorf("Can't get source URL from JSON")
+	}
+
+	r.sourceURL = srcURL
+
+	return err
+}
+
+func (r *Runner) prefetchItemByURL(hc *http.Client, urlPath string) (item *schema.Item, err error) {
+	// Copy r.ServerURL
+	urlItem, _err := url.Parse(r.ServerURL.String())
+	if _err != nil {
+		// Unexpected case
+		return item, erron.Errorwf(_err, "Failed to parse server URL: %v", r.ServerURL)
+	}
+	urlItem.Path = path.Join(urlItem.Path, urlPath)
+
+	headers := make(map[string]string)
+	headers["Accept"] = "application/json"
+	req, err := newHttpGetRequest(urlItem.String(), headers)
+	if err != nil {
+		return item, err
+	}
+	r.Logger.Infof("GET %s", urlItem.String())
+
+	res, _err := hc.Do(req)
+	if _err != nil {
+		err = erron.Errorwf(_err, "Failed to execute HTTP request")
+		return item, err
+	}
+	defer res.Body.Close()
+	switch res.StatusCode {
+	case 200:
+		// OK
+	case 404:
+		r.Logger.Debugf("Index Item Data is Not Found: %s", urlItem.String())
+		return item, errIndexDataNotFound
+	default:
+		err = fmt.Errorf("HTTP response is not OK. Code: %d, URL: %s", res.StatusCode, urlItem.String())
+		return item, err
+	}
+
+	var b strings.Builder
+	_, _err = io.Copy(&b, res.Body)
+	if _err != nil {
+		err = erron.Errorwf(_err, "Failed to read HTTP response")
+		return item, err
+	}
+
+	item, err = schema.DecodeItemJSON([]byte(b.String()))
+	if err != nil {
+		return item, err
+	}
+	r.Logger.Debugf("Decoded JSON: %+v", item)
+
+	return item, nil
+}
+
+func (r *Runner) prefetchItemByIndex(hc *http.Client) (item *schema.Item, err error) {
+	index, _err := r.prefetchIndex(hc, "")
+	switch _err {
+	case nil:
+		// OK
+	case errIndexDataNotFound:
+		if index, _err = r.prefetchIndex(hc, "index.json"); _err != nil {
+			err = erron.Errorwf(_err, "Can't get Index data from server: %s", r.ServerURL.String())
+		}
+		return item, err
+	default:
+		return item, err
+	}
+
+	urlPath := index.FindPath(r.Source)
+	switch urlPath {
+	case "":
+		err = fmt.Errorf("Can't find item in index. Server: %s", r.ServerURL.String())
+		return item, err
+	case r.Source:
+		err = fmt.Errorf(
+			"Found path equals to specified Source. Won't retry. Source: %s, Server: %s",
+			r.Source, r.ServerURL.String())
+		return item, err
+	default:
+		// OK
+	}
+
+	if item, _err = r.prefetchItemByURL(hc, urlPath); _err != nil {
+		err = erron.Errorwf(_err, "Failed to get Item Data on path: %s", urlPath)
+		return item, err
+	}
+
+	return item, nil
+}
+
+func (r *Runner) prefetchIndex(hc *http.Client, url string) (index *schema.Index, err error) {
+	if url == "" {
+		url = r.ServerURL.String()
+	}
+	headers := make(map[string]string)
+	headers["Accept"] = "application/json"
+	req, err := newHttpGetRequest(url, headers)
+	if err != nil {
+		return index, err
+	}
+	r.Logger.Infof("GET %s", url)
+
+	res, _err := hc.Do(req)
+	if _err != nil {
+		err = erron.Errorwf(_err, "Failed to execute HTTP request")
+		return index, err
+	}
+	defer res.Body.Close()
+	switch res.StatusCode {
+	case 200:
+		// OK
+	case 404:
+		r.Logger.Debugf("Index Data is Not Found: %s")
+		return index, errIndexDataNotFound
+	default:
+		err = fmt.Errorf("HTTP response is not OK. Code: %d, URL: %s", res.StatusCode, url)
+		return index, err
+	}
+
+	var b strings.Builder
+	_, _err = io.Copy(&b, res.Body)
+	if _err != nil {
+		err = erron.Errorwf(_err, "Failed to read HTTP response")
+		return index, err
+	}
+
+	index, err = schema.DecodeIndexJSON([]byte(b.String()))
+	if err != nil {
+		return index, err
+	}
+	r.Logger.Debugf("Decoded JSON: %+v", index)
+
+	return index, nil
+}

--- a/schema/index.go
+++ b/schema/index.go
@@ -1,0 +1,45 @@
+package schema
+
+import (
+	"encoding/json"
+
+	"github.com/progrhyme/binq/internal/erron"
+)
+
+type IndiceItem struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
+type Index struct {
+	indexProps
+}
+
+type indexProps struct {
+	Items []IndiceItem `json:"items"`
+}
+
+func DecodeIndexJSON(b []byte) (index *Index, err error) {
+	var ip indexProps
+	if _err := json.Unmarshal(b, &ip); _err != nil {
+		return index, erron.Errorwf(_err, "Failed to unmarshal JSON: %s", b)
+	}
+	index = &Index{indexProps: ip}
+	return index, err
+}
+
+func (idx *Index) Find(name string) (indice *IndiceItem) {
+	for _, i := range idx.Items {
+		if i.Name == name {
+			return &i
+		}
+	}
+	return nil
+}
+
+func (idx *Index) FindPath(name string) (path string) {
+	if item := idx.Find(name); item != nil {
+		return item.Path
+	}
+	return ""
+}


### PR DESCRIPTION
Feature:

- (index,query) Fallback to search INDEX to find ITEM when it first fails to fetch it from server on the path specified as an argument

Bug Fix:

- (cli) Set mode = ModeDLOnly when both `--no-extract` & `--no-exec` options specified

Modify:

- (client) Make client.RunOption visible so that Run is callable from outside