### PR TITLE
Feature: enhance item schema to make url-format more flexible

### DIFF
--- a/client/prefetch.go
+++ b/client/prefetch.go
@@ -100,7 +100,7 @@ func (r *Runner) prefetchItemByURL(hc *http.Client, urlPath string) (item *schem
 	if err != nil {
 		return item, err
 	}
-	r.Logger.Debugf("Decoded JSON: %+v", item)
+	r.Logger.Debugf("Decoded JSON: %s", item)
 
 	return item, nil
 }
@@ -181,7 +181,7 @@ func (r *Runner) prefetchIndex(hc *http.Client, url string) (index *schema.Index
 	if err != nil {
 		return index, err
 	}
-	r.Logger.Debugf("Decoded JSON: %+v", index)
+	r.Logger.Debugf("Decoded JSON: %s", index)
 
 	return index, nil
 }

--- a/cmd/binq/main.go
+++ b/cmd/binq/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"os"
 
-	"github.com/progrhyme/binq/client"
+	"github.com/progrhyme/binq/internal/cli"
 )
 
 func main() {
-	os.Exit(client.NewCLI(os.Stdout, os.Stderr).Run(os.Args))
+	os.Exit(cli.NewCLI(os.Stdout, os.Stderr).Run(os.Args))
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,13 +1,9 @@
 package cli
 
 import (
-	"fmt"
 	"io"
 	"path/filepath"
 
-	"github.com/progrhyme/binq"
-	"github.com/progrhyme/binq/client"
-	"github.com/progrhyme/binq/internal/logs"
 	"github.com/spf13/pflag"
 )
 
@@ -24,87 +20,26 @@ func NewCLI(outs, errs io.Writer) *CLI {
 	return &CLI{OutStream: outs, ErrStream: errs}
 }
 
-func (c *CLI) Run(args []string) (exit int) {
-	prog := filepath.Base(args[0])
-	flags := pflag.NewFlagSet(prog, pflag.ContinueOnError)
-	flags.SetOutput(c.ErrStream)
-	help := flags.BoolP("help", "h", false, "Show help")
-	version := flags.BoolP("version", "V", false, "Show version")
-	target := flags.StringP("target", "t", "", "Target Item (Name or URL)")
-	directory := flags.StringP("directory", "d", "", "Output Directory")
-	file := flags.StringP("file", "f", "", "Output File name")
-	server := flags.StringP("server", "s", "", "Index Server URL")
-	noExtract := flags.BoolP("no-extract", "z", false, "Don't extract archive")
-	noExec := flags.BoolP("no-exec", "X", false, "Don't care for executable files")
-	verbose := flags.BoolP("verbose", "v", false, "Verbose output")
-	debug := flags.Bool("debug", false, "Show debug messages")
-	flags.Usage = func() { c.usage(flags, prog) }
-	if err := flags.Parse(args[1:]); err != nil {
-		fmt.Fprintf(c.ErrStream, "Error! Parsing arguments failed. %s\n", err)
-		return exitNG
-	}
-
-	if *help {
-		flags.Usage()
-		return exitOK
-	} else if *version {
-		fmt.Fprintf(c.OutStream, "Version: %s\n", binq.Version)
-		return exitOK
-	}
-
-	if *target == "" && flags.NArg() == 0 {
-		fmt.Fprintln(c.ErrStream, "Error! Target is not specified!")
-		flags.Usage()
-		return exitNG
-	}
-
-	mode := client.ModeDefault
-	if *noExtract {
-		mode = mode ^ client.ModeExtract
-	}
-	if *noExec {
-		mode = mode ^ client.ModeExecutable
-	}
-	if mode == 0 {
-		mode = client.ModeDLOnly
-	}
-
-	var source string
-	if *target != "" {
-		source = *target
-	} else {
-		source = flags.Arg(0)
-	}
-
-	logLevel := logs.Notice
-	if *debug {
-		logLevel = logs.Debug
-	} else if *verbose {
-		logLevel = logs.Info
-	}
-	opts := client.RunOption{
-		Mode:      mode,
-		Source:    source,
-		DestDir:   *directory,
-		DestFile:  *file,
-		Output:    c.ErrStream,
-		LogLevel:  logLevel,
-		ServerURL: *server,
-	}
-	if err := client.Run(opts); err != nil {
-		fmt.Fprintf(c.ErrStream, "Error! %v\n", err)
-		return exitNG
-	}
-
-	return exitOK
+type commonCmd struct {
+	outs, errs io.Writer
+	prog, name string
+	flags      *pflag.FlagSet
 }
 
-func (c *CLI) usage(fs *pflag.FlagSet, prog string) {
-	fmt.Fprintf(c.ErrStream, `Summary:
-  "%s" does download & extract binary or archive via HTTP; then locate executable files into target
-  directory.
+type commonOpts struct {
+	help, verbose, debug *bool
+}
 
-Options:
-`, prog)
-	fs.PrintDefaults()
+func (c *CLI) Run(args []string) (exit int) {
+	prog := filepath.Base(args[0])
+
+	common := &commonCmd{outs: c.OutStream, errs: c.ErrStream, prog: prog, name: "install"}
+	installer := newInstallCmd(common)
+
+	if len(args) == 1 {
+		installer.usage()
+		return exitNG
+	}
+
+	return installer.run(args[1:])
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,4 +1,4 @@
-package client
+package cli
 
 import (
 	"fmt"
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/progrhyme/binq"
+	"github.com/progrhyme/binq/client"
 	"github.com/progrhyme/binq/internal/logs"
 	"github.com/spf13/pflag"
 )
@@ -56,15 +57,15 @@ func (c *CLI) Run(args []string) (exit int) {
 		return exitNG
 	}
 
-	mode := ModeDefault
+	mode := client.ModeDefault
 	if *noExtract {
-		mode = mode ^ ModeExtract
+		mode = mode ^ client.ModeExtract
 	}
 	if *noExec {
-		mode = mode ^ ModeExecutable
+		mode = mode ^ client.ModeExecutable
 	}
 	if mode == 0 {
-		mode = ModeDLOnly
+		mode = client.ModeDLOnly
 	}
 
 	source := flags.Arg(0)
@@ -75,7 +76,7 @@ func (c *CLI) Run(args []string) (exit int) {
 	} else if *verbose {
 		logLevel = logs.Info
 	}
-	opts := RunOption{
+	opts := client.RunOption{
 		Mode:      mode,
 		Source:    source,
 		DestDir:   *directory,
@@ -84,7 +85,7 @@ func (c *CLI) Run(args []string) (exit int) {
 		LogLevel:  logLevel,
 		ServerURL: *server,
 	}
-	if err := Run(opts); err != nil {
+	if err := client.Run(opts); err != nil {
 		fmt.Fprintf(c.ErrStream, "Error! %v\n", err)
 		return exitNG
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -28,15 +28,16 @@ func (c *CLI) Run(args []string) (exit int) {
 	prog := filepath.Base(args[0])
 	flags := pflag.NewFlagSet(prog, pflag.ContinueOnError)
 	flags.SetOutput(c.ErrStream)
-	help := flags.BoolP("help", "h", false, "show help")
-	version := flags.BoolP("version", "V", false, "show version")
-	noExtract := flags.BoolP("no-extract", "z", false, "don't extract archive")
-	noExec := flags.BoolP("no-exec", "X", false, "don't care for executable files")
-	verbose := flags.BoolP("verbose", "v", false, "verbose output")
-	debug := flags.Bool("debug", false, "show debug messages")
-	directory := flags.StringP("directory", "d", "", "output directory")
-	file := flags.StringP("file", "f", "", "output file name")
-	server := flags.StringP("server", "s", "", "index server URL")
+	help := flags.BoolP("help", "h", false, "Show help")
+	version := flags.BoolP("version", "V", false, "Show version")
+	target := flags.StringP("target", "t", "", "Target Item (Name or URL)")
+	directory := flags.StringP("directory", "d", "", "Output Directory")
+	file := flags.StringP("file", "f", "", "Output File name")
+	server := flags.StringP("server", "s", "", "Index Server URL")
+	noExtract := flags.BoolP("no-extract", "z", false, "Don't extract archive")
+	noExec := flags.BoolP("no-exec", "X", false, "Don't care for executable files")
+	verbose := flags.BoolP("verbose", "v", false, "Verbose output")
+	debug := flags.Bool("debug", false, "Show debug messages")
 	flags.Usage = func() { c.usage(flags, prog) }
 	if err := flags.Parse(args[1:]); err != nil {
 		fmt.Fprintf(c.ErrStream, "Error! Parsing arguments failed. %s\n", err)
@@ -51,7 +52,7 @@ func (c *CLI) Run(args []string) (exit int) {
 		return exitOK
 	}
 
-	if flags.NArg() == 0 {
+	if *target == "" && flags.NArg() == 0 {
 		fmt.Fprintln(c.ErrStream, "Error! Target is not specified!")
 		flags.Usage()
 		return exitNG
@@ -68,7 +69,12 @@ func (c *CLI) Run(args []string) (exit int) {
 		mode = client.ModeDLOnly
 	}
 
-	source := flags.Arg(0)
+	var source string
+	if *target != "" {
+		source = *target
+	} else {
+		source = flags.Arg(0)
+	}
 
 	logLevel := logs.Notice
 	if *debug {

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -1,0 +1,118 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/progrhyme/binq"
+	"github.com/progrhyme/binq/client"
+	"github.com/progrhyme/binq/internal/logs"
+	"github.com/spf13/pflag"
+)
+
+type installCmd struct {
+	*commonCmd
+	option *installOpts
+}
+
+type installOpts struct {
+	target, directory, file, server *string
+	version, noExtract, noExec      *bool
+	*commonOpts
+}
+
+func newInstallCmd(common *commonCmd) (self *installCmd) {
+	self = &installCmd{commonCmd: common}
+
+	fs := pflag.NewFlagSet(self.name, pflag.ContinueOnError)
+	fs.SetOutput(self.errs)
+	self.option = &installOpts{
+		version:   fs.BoolP("version", "V", false, "Show version"),
+		target:    fs.StringP("target", "t", "", "Target Item (Name or URL)"),
+		directory: fs.StringP("directory", "d", "", "Output Directory"),
+		file:      fs.StringP("file", "f", "", "Output File name"),
+		server:    fs.StringP("server", "s", "", "Index Server URL"),
+		noExtract: fs.BoolP("no-extract", "z", false, "Don't extract archive"),
+		noExec:    fs.BoolP("no-exec", "X", false, "Don't care for executable files"),
+		commonOpts: &commonOpts{
+			help:    fs.BoolP("help", "h", false, "Show help"),
+			verbose: fs.BoolP("verbose", "v", false, "Verbose output"),
+			debug:   fs.Bool("debug", false, "Show debug messages"),
+		},
+	}
+	fs.Usage = self.usage
+	self.flags = fs
+
+	return self
+}
+
+func (cmd *installCmd) usage() {
+	fmt.Fprintf(cmd.errs, `Summary:
+  "%s" does download & extract binary or archive via HTTP; then locate executable files into target
+  directory.
+
+Options:
+`, cmd.prog)
+	cmd.flags.PrintDefaults()
+}
+
+func (cmd *installCmd) run(args []string) (exit int) {
+	if err := cmd.flags.Parse(args); err != nil {
+		fmt.Fprintf(cmd.errs, "Error! Parsing arguments failed. %s\n", err)
+		return exitNG
+	}
+
+	opt := cmd.option
+	if *opt.help {
+		cmd.usage()
+		return exitOK
+	} else if *opt.version {
+		fmt.Fprintf(cmd.outs, "Version: %s\n", binq.Version)
+		return exitOK
+	}
+
+	if *opt.target == "" && cmd.flags.NArg() == 0 {
+		fmt.Fprintln(cmd.errs, "Error! Target is not specified!")
+		cmd.usage()
+		return exitNG
+	}
+
+	mode := client.ModeDefault
+	if *opt.noExtract {
+		mode = mode ^ client.ModeExtract
+	}
+	if *opt.noExec {
+		mode = mode ^ client.ModeExecutable
+	}
+	if mode == 0 {
+		mode = client.ModeDLOnly
+	}
+
+	var source string
+	if *opt.target != "" {
+		source = *opt.target
+	} else {
+		source = cmd.flags.Arg(0)
+	}
+
+	logLevel := logs.Notice
+	if *opt.debug {
+		logLevel = logs.Debug
+	} else if *opt.verbose {
+		logLevel = logs.Info
+	}
+	opts := client.RunOption{
+		Mode:      mode,
+		Source:    source,
+		DestDir:   *opt.directory,
+		DestFile:  *opt.file,
+		Output:    cmd.errs,
+		LogLevel:  logLevel,
+		ServerURL: *opt.server,
+	}
+	if err := client.Run(opts); err != nil {
+		fmt.Fprintf(cmd.errs, "Error! %v\n", err)
+		return exitNG
+	}
+
+	return exitOK
+}

--- a/schema/index.go
+++ b/schema/index.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/progrhyme/binq/internal/erron"
 )
@@ -12,7 +13,7 @@ type IndiceItem struct {
 }
 
 type Index struct {
-	indexProps
+	*indexProps
 }
 
 type indexProps struct {
@@ -24,8 +25,12 @@ func DecodeIndexJSON(b []byte) (index *Index, err error) {
 	if _err := json.Unmarshal(b, &ip); _err != nil {
 		return index, erron.Errorwf(_err, "Failed to unmarshal JSON: %s", b)
 	}
-	index = &Index{indexProps: ip}
+	index = &Index{indexProps: &ip}
 	return index, err
+}
+
+func (idx *Index) String() string {
+	return fmt.Sprintf("%+v", *idx.indexProps)
 }
 
 func (idx *Index) Find(name string) (indice *IndiceItem) {

--- a/schema/item.go
+++ b/schema/item.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"encoding/json"
+	"fmt"
 	"html/template"
 	"strings"
 
@@ -10,7 +11,7 @@ import (
 
 // Item wraps itemProps which corresponds to JSON structure of item data
 type Item struct {
-	itemProps
+	*itemProps
 }
 
 type ItemRevision struct {
@@ -52,8 +53,12 @@ func DecodeItemJSON(b []byte) (item *Item, err error) {
 	if _err := json.Unmarshal(b, &i); _err != nil {
 		return item, erron.Errorwf(_err, "Failed to unmarshal JSON: %s", b)
 	}
-	item = &Item{itemProps: i}
+	item = &Item{itemProps: &i}
 	return item, err
+}
+
+func (i *Item) String() string {
+	return fmt.Sprintf("%+v", *i.itemProps)
 }
 
 func (i *Item) GetLatestURL(param ItemURLParam) (url string, err error) {


### PR DESCRIPTION
Feature:

- (schema/item) Support `{{.BinExt}}` in "url-format" which is replaced with `.exe` on Windows, blank on others
- (schema/item) Support `{{.Ext}}` in "url-format" to customize file extension. Replacement for it is defined by "extension" hash in JSON

Change:

- (client) Unexport type `CLI`