### PR TITLE
[enhance][checksum] Support MD5 checksum

### DIFF
--- a/internal/cli/revise.go
+++ b/internal/cli/revise.go
@@ -78,8 +78,12 @@ Parameters:
 
   Format: "<File1>:<Checksum1>[:<Algorithm1>],..."
 
-  SHA-256 is the default algorithm. To use CRC, specify like this: '-s "foo.zip:1093117945:crc"'.
+  SHA-256 is the default algorithm. To use CRC or MD5, specify suffix ":crc" or ":md5" like this:
+  '-s "foo.zip:5993c24b:crc"'.
   Other algorithm is not supported for now.
+
+Limitation:
+  It is not expected to specify two or more types of checksums per file.
 
 Options:
 `

--- a/schema/item/checksum.go
+++ b/schema/item/checksum.go
@@ -1,6 +1,7 @@
 package item
 
 import (
+	"crypto/md5"
 	"crypto/sha256"
 	"hash"
 	"hash/crc32"
@@ -14,6 +15,7 @@ type ChecksumType int
 const (
 	ChecksumTypeSHA256 ChecksumType = iota + 1
 	ChecksumTypeCRC
+	ChecksumTypeMD5
 	ChecksumTypeUnknown ChecksumType = -1
 )
 
@@ -22,6 +24,7 @@ type ItemChecksum struct {
 	SHA256 string `json:"sha256,omitempty"`
 	// CRC-32 IEEE Std.
 	CRC string `json:"crc,omitempty"`
+	MD5 string `json:"md5,omitempty"`
 }
 
 func NewItemChecksums(arg string) (sums []ItemChecksum) {
@@ -40,6 +43,8 @@ func NewItemChecksums(arg string) (sums []ItemChecksum) {
 				sums = append(sums, ItemChecksum{File: params[0], SHA256: params[1]})
 			case "crc", "CRC":
 				sums = append(sums, ItemChecksum{File: params[0], CRC: params[1]})
+			case "md5", "MD5":
+				sums = append(sums, ItemChecksum{File: params[0], MD5: params[1]})
 			default:
 				lv.Warnf("Unsupported algorithm: %s. Param: %s", params[2], entry)
 			}
@@ -56,6 +61,8 @@ func (sum *ItemChecksum) GetSumAndHasher() (s string, h hash.Hash, t ChecksumTyp
 		return sum.SHA256, sha256.New(), ChecksumTypeSHA256
 	} else if sum.CRC != "" {
 		return sum.CRC, crc32.NewIEEE(), ChecksumTypeCRC
+	} else if sum.MD5 != "" {
+		return sum.MD5, md5.New(), ChecksumTypeMD5
 	}
 	return "", nil, ChecksumTypeUnknown
 }
@@ -65,7 +72,9 @@ func (sum *ItemChecksum) SetSum(val string, t ChecksumType) {
 	case ChecksumTypeSHA256:
 		sum.SHA256 = val
 	case ChecksumTypeCRC:
-		sum.SHA256 = val
+		sum.CRC = val
+	case ChecksumTypeMD5:
+		sum.MD5 = val
 	default:
 		// Unexpected
 		lv.Fatalf("Unsupported type for checksum: %d", t)


### PR DESCRIPTION
Bug Fix:

- (schema/item,CLI/verify) It wrongly set SHA256 value when CRC is expected