### PR TITLE
Feature: Provide default index server https://binqry.github.io/index/

### DIFF
--- a/binq.go
+++ b/binq.go
@@ -1,7 +1,8 @@
 package binq
 
 const (
-	Version      = "0.7.0"
-	EnvKeyServer = "BINQ_SERVER"  // URL of Index Server for install operation
-	EnvKeyBinDir = "BINQ_BIN_DIR" // Default location to download items
+	Version           = "0.7.0"
+	DefaultBinqServer = "https://binqry.github.io/index/"
+	EnvKeyServer      = "BINQ_SERVER"  // URL of Index Server for install operation
+	EnvKeyBinDir      = "BINQ_BIN_DIR" // Default location to download items
 )

--- a/client/client.go
+++ b/client/client.go
@@ -77,6 +77,8 @@ func Run(opt RunOption) (err error) {
 		urlStr = opt.ServerURL
 	} else if server := os.Getenv(binq.EnvKeyServer); server != "" {
 		urlStr = server
+	} else {
+		urlStr = binq.DefaultBinqServer
 	}
 	if urlStr != "" {
 		uri, _err := url.Parse(urlStr)

--- a/client/client.go
+++ b/client/client.go
@@ -10,10 +10,10 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/mholt/archiver/v3"
 	"github.com/binqry/binq"
 	"github.com/binqry/binq/internal/erron"
 	"github.com/binqry/binq/schema/item"
+	"github.com/mholt/archiver/v3"
 	"github.com/progrhyme/go-lv"
 )
 

--- a/go.sum
+++ b/go.sum
@@ -9,7 +9,6 @@ github.com/golang/gddo v0.0.0-20190419222130-af0f2af80721 h1:KRMr9A3qfbVM7iV/WcL
 github.com/golang/gddo v0.0.0-20190419222130-af0f2af80721/go.mod h1:xEhNfoBDX1hzLm2Nf80qUvZ2sVwoMZ8d6IE2SrsQfh4=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -5,9 +5,9 @@ import (
 	"io"
 	"strings"
 
+	"github.com/binqry/binq/internal/erron"
 	"github.com/gookit/color"
 	"github.com/pmezard/go-difflib/difflib"
-	"github.com/binqry/binq/internal/erron"
 	"golang.org/x/crypto/ssh/terminal"
 )
 

--- a/internal/cli/modify.go
+++ b/internal/cli/modify.go
@@ -141,6 +141,11 @@ func (cmd *modifyCmd) run(args []string) (exit int) {
 
 	oldPathItem = filepath.Join(filepath.Dir(fileIndex), oldPathItem)
 	newPathItem = filepath.Join(filepath.Dir(fileIndex), newPathItem)
+	newDir := filepath.Dir(newPathItem)
+	if err = os.MkdirAll(newDir, 0755); err != nil {
+		fmt.Fprintf(cmd.errs, "Error! Can't make directory: %s. %v\n", newDir, err)
+		return exitNG
+	}
 	if err = os.Rename(oldPathItem, newPathItem); err != nil {
 		fmt.Fprintf(cmd.errs, "Error! Failed to move file: %s => %s. %v\n", oldPathItem, newPathItem, err)
 		return exitNG

--- a/internal/cli/register.go
+++ b/internal/cli/register.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/progrhyme/go-lv"
 	"github.com/binqry/binq/schema"
 	"github.com/binqry/binq/schema/item"
+	"github.com/progrhyme/go-lv"
 	"github.com/spf13/pflag"
 )
 

--- a/schema/item/item.go
+++ b/schema/item/item.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/hashicorp/go-version"
 	"github.com/binqry/binq/internal/erron"
+	"github.com/hashicorp/go-version"
 	"github.com/progrhyme/go-lv"
 )
 


### PR DESCRIPTION
Feature:

- (client, CLI/install) Set default index server to https://binqry.github.io/index/

Bug Fix:

- (CLI/modify) Can't move file to new path when directory doesn't exist
